### PR TITLE
Updated jQuery and jQuery UI file references to be in sync with NuGet package references

### DIFF
--- a/Juice/JuiceApp.cs
+++ b/Juice/JuiceApp.cs
@@ -24,20 +24,20 @@ namespace Juice {
 
 			ScriptManager.ScriptResourceMapping.AddDefinition("jquery",
 					new ScriptResourceDefinition {
-						Path = "~/Scripts/jquery-1.7.1.min.js",
-						DebugPath = "~/Scripts/jquery-1.7.1.js",
-						CdnPath = "http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js",
-						CdnDebugPath = "http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.js",
+						Path = "~/Scripts/jquery-1.8.0.min.js",
+						DebugPath = "~/Scripts/jquery-1.8.0.js",
+						CdnPath = "http://ajax.googleapis.com/ajax/libs/jquery/1.8.0/jquery.min.js",
+						CdnDebugPath = "http://ajax.googleapis.com/ajax/libs/jquery/1.8.0/jquery.js",
 						CdnSupportsSecureConnection = true
 					}
 			);
 
 			ScriptManager.ScriptResourceMapping.AddDefinition("jquery-ui",
 					new ScriptResourceDefinition {
-						Path = "~/Scripts/jquery-ui-1.8.18.min.js",
-						DebugPath = "~/Scripts/jquery-ui-1.8.18.js",
-						CdnPath = "http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.18/jquery-ui.min.js",
-						CdnDebugPath = "http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.18/jquery-ui.js",
+						Path = "~/Scripts/jquery-ui-1.8.23.min.js",
+						DebugPath = "~/Scripts/jquery-ui-1.8.23.js",
+						CdnPath = "http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.23/jquery-ui.min.js",
+						CdnDebugPath = "http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.23/jquery-ui.js",
 						CdnSupportsSecureConnection = true
 					}
 			);

--- a/Juice/Properties/juice.nuspec
+++ b/Juice/Properties/juice.nuspec
@@ -29,7 +29,7 @@
 		]]></releaseNotes>
     <dependencies>
       <dependency id="jQuery" version="1.8.0" />
-      <dependency id="jQuery.UI.Combined" version="1.8.22" />
+      <dependency id="jQuery.UI.Combined" version="1.8.23" />
       <dependency id="json2" />
       <dependency id="AmplifyJS" />
     </dependencies>


### PR DESCRIPTION
Dependencies were mismatched and causing errors when running the sample application. Nuget loads in jQuery 1.8.0 and JuiceApp.cs registers script reference for jQuery 1.7.1. This results in a 404.

Updated them to be in sync. jQuery is now 1.8.0 and jQuery UI is now 1.8.23

See changeset here: https://github.com/banzor/juiceui/commit/85cc6463d45948b63156b92fd59d07870b7d74f8
